### PR TITLE
Add CodeTriage.com (from Boston) in Resources.md.

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -91,6 +91,7 @@ All are language-agnostic.
 
 ## Getting Involved in Open Source
 
+* [Code Triage] (http://www.codetriage.com/): Pick a language and help push issues to get resolved one comment at a time.
 * [24 Pull Requests](http://24pullrequests.com/)
     * See their [Contributing](http://24pullrequests.com/contributing) page for guides
 * [BountySource](https://www.bountysource.com/)


### PR DESCRIPTION
You all have such a great resources page, thank you! I just told a New Yorker who is going to teach AP Computer Science to High Schoolers this year [1]. I realized you were missing one of my all time favorite sites, CodeTriage [2]! 

[1] Blogger solicits ideas for teaching. http://www.kchodorow.com/blog/2014/07/15/sharing-programming/
[2] In vein of 24-pull requests, but even simpler: find projects with lots of open tickets and comment on them to move them forward. Naturally, PR's welcome too, but I have found that reading code this way is really helpful and warms one up to doing a PR.  http://www.codetriage.com/ 
