### PR TITLE
Open Source Workshop page

### DIFF
--- a/_data/oss_workshop/participants/afeld.yml
+++ b/_data/oss_workshop/participants/afeld.yml
@@ -1,0 +1,3 @@
+name: Aidan Feldman
+title: Developer by day, dancer by night
+emoji: 'dancer'

--- a/_includes/oss_workshop/participants.html
+++ b/_includes/oss_workshop/participants.html
@@ -1,5 +1,5 @@
 <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet">
-<ul class="oss-workshop-participants">
+<ul>
   {% for user_hash in site.data.oss_workshop.participants %}
   {% assign username = user_hash[0] %}
   {% assign user = user_hash[1] %}

--- a/_includes/oss_workshop/participants.html
+++ b/_includes/oss_workshop/participants.html
@@ -1,0 +1,21 @@
+<link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet">
+<ul>
+  {% for user_hash in site.data.oss_workshop.participants %}
+  {% assign username = user_hash[0] %}
+  {% assign user = user_hash[1] %}
+
+  <li>
+    {% assign emoji = user.emoji | replace:'+','--' %}
+    <div>
+      <strong>{{ user.name }}</strong>
+      <i class="em em-{{ emoji }}"></i>
+    </div>
+    <div>
+      {{ user.title }}
+    </div>
+    <div>
+      <a href="https://github.com/{{ username }}">github.com/{{ username }}</a>
+    </div>
+  </li>
+  {% endfor %}
+</ul>

--- a/_includes/oss_workshop/participants.html
+++ b/_includes/oss_workshop/participants.html
@@ -1,5 +1,5 @@
 <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet">
-<ul>
+<ul class="oss-workshop-participants">
   {% for user_hash in site.data.oss_workshop.participants %}
   {% assign username = user_hash[0] %}
   {% assign user = user_hash[1] %}
@@ -7,14 +7,11 @@
   <li>
     {% assign emoji = user.emoji | replace:'+','--' %}
     <div>
-      <strong>{{ user.name }}</strong>
+      <span class="name"><a href="https://github.com/{{ username }}" class="github-username">@{{ username }}</a> – {{ user.name }}</span>
       <i class="em em-{{ emoji }}"></i>
     </div>
     <div>
       {{ user.title }}
-    </div>
-    <div>
-      <a href="https://github.com/{{ username }}">github.com/{{ username }}</a>
     </div>
   </li>
   {% endfor %}

--- a/css/style.scss
+++ b/css/style.scss
@@ -121,6 +121,25 @@ h4 {
   }
 }
 
+/* open source workshop */
+.oss-workshop-participants {
+  .name {
+    font-size: 1.1em;
+  }
+
+  .github-username {
+    color: black;
+    // copy from GitHub
+    font-family: Helvetica, 'Segoe UI', Arial, freesans, sans-serif;
+    font-weight: bold;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
 
 @media all and (max-width: 640px) {
   /* narrow browser */

--- a/css/style.scss
+++ b/css/style.scss
@@ -122,7 +122,12 @@ h4 {
 }
 
 /* open source workshop */
-.oss-workshop-participants {
+.page-oss-workshop {
+  .event-details {
+    font-size: 1.2em;
+    font-style: italic;
+  }
+
   .name {
     font-size: 1.1em;
   }

--- a/css/style.scss
+++ b/css/style.scss
@@ -14,11 +14,15 @@ h1 {
 img {
   max-width: 100%;
 }
+pre,
 code {
   background-color: #fcfcfc;
   border-radius: 4px;
   border: 1px solid #c5c5c5;
   padding: 2px;
+}
+pre code {
+  border: none;
 }
 .navbar a {
   font-family: 'Merriweather', serif;

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -2,7 +2,24 @@
 title: Open Source Workshop
 ---
 
+4/26/15 12-5pm, [Projective Space LES](http://www.projective.co/)
+{: .event-details}
+
+This is a workshop for people new to open source – we will try to have activities for every skill level / skillset. We’re still working out details around what project(s) we’ll be contributing to, but it will be some combination of:
+
+* Improving documentation
+* Writing tutorials/guides
+* Collecting resources
+* Adding features
+* Adding tests
+* Fixing bugs
+* Helping other people do all of these things
+
+In order to have everyone with a baseline level of setup/knowledge, we ask that you get set up with GitHub and learn how to submit a pull request in order to RSVP. Please follow the steps below to do so. If you're interested in helping out as a project maintainer or a mentor, [get in touch](mailto:hackerhoursnyc@gmail.com)!
+
 ## How to RSVP
+
+<!-- ripping off of http://18f.github.io/hourofcode/ -->
 
 1. If you don't have one already, start by [creating a Github account](https://github.com).
 1. Visit the participant source files [here](https://github.com/afeld/hackerhours.org/tree/gh-pages/_data/oss_workshop/participants).
@@ -17,6 +34,10 @@ title: Open Source Workshop
 1. Click on the green button "Propose new file"
 1. Click on the green button "Create pull request"
 
+Now go and **RSVP through [the meetup](TODO)**, and you're in! If you want to get a head start with building up your open source skills, check out [our resources](/resources.html#getting-involved-in-open-source).
+
 ## Awesome Open Source Contributors
+
+a.k.a. the RSVP list!
 
 {% include oss_workshop/participants.html %}

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -17,7 +17,9 @@ This is a workshop for people new to open source – we will try to have activit
 * Fixing bugs
 * Helping other people do all of these things
 
-In order to have everyone with a baseline level of setup/knowledge, we ask that you get set up with GitHub and learn how to submit a pull request in order to RSVP. Please follow the steps below to do so. If you're interested in helping out as a project maintainer or a mentor, [get in touch](mailto:hackerhoursnyc@gmail.com)!
+In order to have everyone with a baseline level of setup/knowledge, we ask that you get set up with GitHub and learn how to submit a pull request in order to RSVP. Please follow the steps below to do so.
+
+Interested in having people contribute to your open source project? Would you like to mentor? Want to ask a question? Have a suggestion for how we could make this workshop better? [Drop us a line!](https://github.com/afeld/hackerhours.org/issues/new)
 
 ## How to RSVP
 

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -2,7 +2,7 @@
 title: Open Source Workshop
 ---
 
-4/26/15 12-5pm, [Projective Space LES](http://www.projective.co/)
+4/26/15 12-5pm, [Projective Space LES](http://www.projective.co/), 72 Allen St. 3rd Floor, NYC
 {: .event-details}
 
 This is a workshop for people new to open source – we will try to have activities for every skill level / skillset. We’re still working out details around what project(s) we’ll be contributing to, but it will be some combination of:

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -40,7 +40,7 @@ Should take less than ten minutes.
 1. Click the green "Propose new file" button.
 1. Click the green "Create pull request" button.
 
-Note that we have a limited number of spots – **you will get an email when we've confirmed your RSVP**. If you want to get a head start with building up your open source skills, check out [the Resources page](/resources.html#getting-involved-in-open-source).
+Note that we have a limited number of spots – **you will get an email when we've confirmed your RSVP**. We will send any announcements to the Hacker Hours mailing list, so make sure you are part of [the meetup group](http://www.meetup.com/hackerhours/). If you want to get a head start with building up your open source skills, check out [the Resources page](/resources.html#getting-involved-in-open-source).
 
 ## Awesome Open Source Contributors
 

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -21,20 +21,22 @@ In order to have everyone with a baseline level of setup/knowledge, we ask that 
 
 <!-- ripping off of http://18f.github.io/hourofcode/ -->
 
+Should take less than ten minutes.
+
 1. If you don't have one already, start by [creating a Github account](https://github.com).
 1. Visit the participant source files [here](https://github.com/afeld/hackerhours.org/tree/gh-pages/_data/oss_workshop/participants).
 1. Click on the blue `+` sign next to the header `hackerhours.org/_data/oss_workshop/participants/+`.
 1. In the "Name your file..." box, type in your GitHub username (which is displayed in the top right of your screen) followed by `.yml`. For example: `janesmith1.yml`
-1. Copy this text and then fill in your own info. For the emoji, pick your favorite icon [from this list](http://www.emoji-cheat-sheet.com/) – have fun with it!
+1. Copy the text below into the editor, and replace  your own info. For the emoji, pick your favorite icon [from this list](http://www.emoji-cheat-sheet.com/). Have some fun with it!
 
         name: Cookie Monster
         title: Cookie is for me
         emoji: 'cookie'
 
-1. Click on the green button "Propose new file"
-1. Click on the green button "Create pull request"
+1. Click the green "Propose new file" button.
+1. Click the green "Create pull request" button.
 
-Now go and **RSVP through [the meetup](TODO)**, and you're in! If you want to get a head start with building up your open source skills, check out [our resources](/resources.html#getting-involved-in-open-source).
+Note that we have a limited number of spots – **you will get an email when we've confirmed your RSVP**. If you want to get a head start with building up your open source skills, check out [the Resources page](/resources.html#getting-involved-in-open-source).
 
 ## Awesome Open Source Contributors
 

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -10,11 +10,9 @@ title: Open Source Workshop
 1. In the "Name your file..." box, type in your GitHub username (which is displayed in the top right of your screen) followed by `.yml`. For example: `janesmith1.yml`
 1. Copy this text and then fill in your own info. For the emoji, pick your favorite icon [from this list](http://www.emoji-cheat-sheet.com/) – have fun with it!
 
-    ```yaml
-    name: Cookie Monster
-    title: Cookie is for me
-    emoji: 'cookie'
-    ```
+        name: Cookie Monster
+        title: Cookie is for me
+        emoji: 'cookie'
 
 1. Click on the green button "Propose new file"
 1. Click on the green button "Create pull request"

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -5,6 +5,8 @@ title: Open Source Workshop
 4/26/15 12-5pm, [Projective Space LES](http://www.projective.co/), 72 Allen St. 3rd Floor, NYC
 {: .event-details}
 
+Did you know you can make meaningful contributions to the code powering thousands of websites, and running on millions of browsers? Absolutely! You can improve your coding, technical writing and collaboration skills, expand your professional network, and help advance the art of software engineering all in one fun way—contribute to open source! It looks good on your resume, teaches you how to be thorough and work within teams, and gives you inside access to some of the coolest projects being built.
+
 This is a workshop for people new to open source – we will try to have activities for every skill level / skillset. We’re still working out details around what project(s) we’ll be contributing to, but it will be some combination of:
 
 * Improving documentation

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -1,0 +1,24 @@
+---
+title: Open Source Workshop
+---
+
+## How to RSVP
+
+1. If you don't have one already, start by [creating a Github account](https://github.com).
+1. Visit the participant source files [here](https://github.com/afeld/hackerhours.org/tree/gh-pages/_data/oss_workshop/participants).
+1. Click on the blue `+` sign next to the header `hackerhours.org/_data/oss_workshop/participants/+`.
+1. In the "Name your file..." box, type in your GitHub username (which is displayed in the top right of your screen) followed by `.yml`. For example: `janesmith1.yml`
+1. Copy this text and then fill in your own info. For the emoji, pick your favorite icon [from this list](http://www.emoji-cheat-sheet.com/) – have fun with it!
+
+    ```yaml
+    name: Cookie Monster
+    title: Cookie is for me
+    emoji: 'cookie'
+    ```
+
+1. Click on the green button "Propose new file"
+1. Click on the green button "Create pull request"
+
+## Awesome Open Source Contributors
+
+{% include oss_workshop/participants.html %}

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -5,7 +5,7 @@ title: Open Source Workshop
 4/26/15 12-5pm, [Projective Space LES](http://www.projective.co/), 72 Allen St. 3rd Floor, NYC
 {: .event-details}
 
-Did you know you can make meaningful contributions to the code powering thousands of websites, and running on millions of browsers? Absolutely! You can improve your coding, technical writing and collaboration skills, expand your professional network, and help advance the art of software engineering all in one fun way—contribute to open source! It looks good on your resume, teaches you how to be thorough and work within teams, and gives you inside access to some of the coolest projects being built.
+Did you know you can make meaningful contributions to the code powering thousands of websites, and running in millions of browsers? You can improve your coding, technical writing and collaboration skills, expand your professional network, and help advance the art of software engineering all in one fun way: contribute to open source! It looks good on your resume, teaches you how to be thorough and work within teams, and gives you inside access to some of the coolest projects being built.
 
 This is a workshop for people new to open source – we will try to have activities for every skill level / skillset. We’re still working out details around what project(s) we’ll be contributing to, but it will be some combination of:
 

--- a/oss-workshop.md
+++ b/oss-workshop.md
@@ -40,7 +40,7 @@ Should take less than ten minutes.
 1. Click the green "Propose new file" button.
 1. Click the green "Create pull request" button.
 
-Note that we have a limited number of spots – **you will get an email when we've confirmed your RSVP**. We will send any announcements to the Hacker Hours mailing list, so make sure you are part of [the meetup group](http://www.meetup.com/hackerhours/). If you want to get a head start with building up your open source skills, check out [the Resources page](/resources.html#getting-involved-in-open-source).
+Note that we have a limited number of spots – **you will get an email when we've confirmed your RSVP. We will send any announcements to the Hacker Hours mailing list, so make sure you are part of [the meetup group](http://www.meetup.com/hackerhours/)**. If you want to get a head start with building up your open source skills, check out [the Resources page](/resources.html#getting-involved-in-open-source).
 
 ## Awesome Open Source Contributors
 


### PR DESCRIPTION
Finally putting together the homepage for the Open Source workshop, as described here:

https://docs.google.com/document/d/1xyYIkeZ_htZ76tmrA06UakSvkOX7ghWL4RG7Gr6oIbE/edit

Note that the RSVP mechanics very closely resemble the "Bonus Round" on http://18f.github.io/hourofcode/ that @leahbannon and I put together.
## Open questions
- Does the description make sense – and do the instructions work – for someone without any context?
- What information am I forgetting?
- Do we need to know people's skill levels and/or preferred programming languages in advance?
- Do people need to RSVP through Meetup as well?
  - Feels a bit redundant, but would be nice to have a way to email attendees before/after the event. I suppose we could just leave comments on all the PRs if we need to...
- What's a better name for the event?
## TODOs
- [ ] Create event on Meetup (even if RSVPs aren't done there)
- [ ] Announce to Hacker Hours mailing list

---

/cc @gabekneisley @melodykramer @wslack @ultrasaurus @jdaudier 
