### PR TITLE
Center header

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -32,7 +32,7 @@ pre code {
   border: none;
 }
 
-nav {
+.navbar {
   text-align: center;
 }
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -31,6 +31,11 @@ code {
 pre code {
   border: none;
 }
+
+nav {
+  text-align: center;
+}
+
 .navbar a {
   font-family: 'Merriweather', serif;
   color: gray;


### PR DESCRIPTION
@afeld @orta 

I worked on fixing a different issue earlier for using HTML 5 semantic tags, and then worked on centering the header (only because I thought it may look nice). I was using the HTML 5 semantic tag, but because that's in a separate pull request which hasn't been merged I had to go back on this branch and change the css to reference the class name `.navbar` instead of the tag name `nav`.
