### PR TITLE
Remove Google Helpouts from tutoring services

### DIFF
--- a/tutors.md
+++ b/tutors.md
@@ -6,7 +6,6 @@ title: Tutors
 
 * [AirPair](https://www.airpair.com)
 * [Codementor](https://www.codementor.io)
-* [Google Helpouts](https://helpouts.google.com)
 * [HackHands](http://www.hackhands.com/)
 * [OnScreenExpert](https://www.onscreenexpert.com/)
 * Thoughtbot Coaching


### PR DESCRIPTION
It was shutdown on April 20, 2015 https://support.google.com/helpouts/answer/6168100?rd=1
